### PR TITLE
fix: migrate to scoped plugin-sdk subpath imports for OpenClaw 2026.4.x

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/core";
 import { zulipPlugin } from "./src/channel.js";
 import { setZulipRuntime } from "./src/runtime.js";
 import {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,3 +1,4 @@
+import { resolveAllowlistProviderRuntimeGroupPolicy, resolveDefaultGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
 import {
   applyAccountNameToChannelSection,
   buildChannelConfigSchema,
@@ -6,15 +7,12 @@ import {
   formatPairingApproveHint,
   migrateBaseNameToDefaultAccount,
   normalizeAccountId,
-  resolveAllowlistProviderRuntimeGroupPolicy,
-  resolveDefaultGroupPolicy,
   resolveThreadSessionKeys,
   setAccountEnabledInConfigSection,
-  type ChannelMessageActionAdapter,
-  type ChannelMessageActionName,
-  type ChannelPlugin,
-  type OpenClawConfig,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/core";
+import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "openclaw/plugin-sdk/channel-contract";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-entry-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { ZulipConfigSchema } from "./config-schema.js";
 import { resolveZulipGroupRequireMention } from "./group-mentions.js";
 import {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -4,7 +4,7 @@ import {
   GroupPolicySchema,
   MarkdownConfigSchema,
   requireOpenAllowFrom,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/channel-config-primitives";
 import { z } from "zod";
 
 const ZulipAccountSchemaBase = z

--- a/src/group-mentions.ts
+++ b/src/group-mentions.ts
@@ -1,4 +1,4 @@
-import type { ChannelGroupContext } from "openclaw/plugin-sdk";
+import type { ChannelGroupContext } from "openclaw/plugin-sdk/channel-contract";
 import { resolveZulipAccount } from "./zulip/accounts.js";
 
 export function resolveZulipGroupRequireMention(

--- a/src/onboarding-helpers.ts
+++ b/src/onboarding-helpers.ts
@@ -1,1 +1,1 @@
-export { promptAccountId } from "openclaw/plugin-sdk";
+export { promptAccountId } from "openclaw/plugin-sdk/setup";

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,4 +1,5 @@
-import type { ChannelOnboardingAdapter, OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk";
+import type { ChannelOnboardingAdapter } from "openclaw/plugin-sdk/channel-lifecycle";
+import type { OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk/core";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   listZulipAccountIds,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 
 let runtime: PluginRuntime | null = null;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "openclaw/plugin-sdk";
+import type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/channel-config-primitives";
+import type { BlockStreamingCoalesceConfig } from "openclaw/plugin-sdk/config-runtime";
 
 export type ZulipChatMode = "oncall" | "onmessage" | "onchar";
 

--- a/src/zulip/accounts.ts
+++ b/src/zulip/accounts.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { ZulipAccountConfig, ZulipChatMode } from "../types.js";
 import { normalizeZulipBaseUrl } from "./client.js";

--- a/src/zulip/monitor-auth.ts
+++ b/src/zulip/monitor-auth.ts
@@ -1,4 +1,5 @@
-import { resolveAllowlistMatchSimple, resolveEffectiveAllowFromLists } from "openclaw/plugin-sdk";
+import { resolveAllowlistMatchSimple } from "openclaw/plugin-sdk/allow-from";
+import { resolveEffectiveAllowFromLists } from "openclaw/plugin-sdk/channel-policy";
 
 export function normalizeZulipAllowEntry(entry: string): string {
   const trimmed = entry.trim();

--- a/src/zulip/monitor-helpers.ts
+++ b/src/zulip/monitor-helpers.ts
@@ -1,8 +1,7 @@
-import {
-  formatInboundFromLabel as formatInboundFromLabelShared,
-  resolveThreadSessionKeys as resolveThreadSessionKeysShared,
-} from "openclaw/plugin-sdk";
-export { createDedupeCache, rawDataToString } from "openclaw/plugin-sdk";
+import { formatInboundFromLabel as formatInboundFromLabelShared } from "openclaw/plugin-sdk/channel-inbound";
+import { resolveThreadSessionKeys as resolveThreadSessionKeysShared } from "openclaw/plugin-sdk/core";
+export { rawDataToString } from "openclaw/plugin-sdk/browser-support";
+export { createDedupeCache } from "openclaw/plugin-sdk/core";
 
 export const formatInboundFromLabel = formatInboundFromLabelShared;
 

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -3,30 +3,25 @@ import type {
   ChatType,
   OpenClawConfig,
   ReplyPayload,
-  RuntimeEnv,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/core";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/plugin-runtime";
+import { buildAgentMediaPayload } from "openclaw/plugin-sdk/agent-media-payload";
+import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
+import { logInboundDrop } from "openclaw/plugin-sdk/channel-inbound";
+import { createReplyPrefixOptions, createTypingCallbacks } from "openclaw/plugin-sdk/channel-reply-pipeline";
+import { DM_GROUP_ACCESS_REASON, readStoreAllowFromForDmPolicy, resolveDmGroupAccessWithLists } from "openclaw/plugin-sdk/channel-policy";
+import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
+import { buildPendingHistoryContextFromMap, clearHistoryEntriesIfEnabled, recordPendingHistoryEntryIfEnabled } from "openclaw/plugin-sdk/reply-history";
 import {
-  buildAgentMediaPayload,
-  DM_GROUP_ACCESS_REASON,
-  createScopedPairingAccess,
-  createReplyPrefixOptions,
-  createTypingCallbacks,
-  logInboundDrop,
-  logTypingFailure,
-  buildPendingHistoryContextFromMap,
-  clearHistoryEntriesIfEnabled,
-  DEFAULT_GROUP_HISTORY_LIMIT,
-  recordPendingHistoryEntryIfEnabled,
   isDangerousNameMatchingEnabled,
-  resolveControlCommandGate,
-  readStoreAllowFromForDmPolicy,
-  resolveDmGroupAccessWithLists,
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
-  resolveChannelMediaMaxBytes,
   warnMissingProviderGroupPolicyFallbackOnce,
-  type HistoryEntry,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/config-runtime";
+import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk/media-runtime";
+import { normalizeAccountId } from "openclaw/plugin-sdk/core";
+import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
+import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { getZulipRuntime } from "../runtime.js";
 import { resolveZulipAccount } from "./accounts.js";
 import {
@@ -52,6 +47,35 @@ import { resolveOncharPrefixes, stripOncharPrefix } from "./monitor-onchar.js";
 import { runWithReconnect } from "./reconnect.js";
 import { sendMessageZulip } from "./send.js";
 import { resolveZulipGroupRequireMention } from "../group-mentions.js";
+
+// Inline helper: createScopedPairingAccess not exported from plugin-sdk subpaths in 2026.4.x
+function createScopedPairingAccess(params: {
+  core: { channel: { pairing: { readAllowFromStore: (p: { channel: string; accountId: string }) => Promise<string[]>; upsertPairingRequest: (p: any) => Promise<{ code: string; created: boolean }> } } };
+  channel: string;
+  accountId: string;
+}) {
+  const resolvedAccountId = normalizeAccountId(params.accountId);
+  return {
+    accountId: resolvedAccountId,
+    readAllowFromStore: () =>
+      params.core.channel.pairing.readAllowFromStore({
+        channel: params.channel,
+        accountId: resolvedAccountId,
+      }),
+    readStoreForDmPolicy: (provider: string, accountId: string) =>
+      params.core.channel.pairing.readAllowFromStore({
+        channel: provider,
+        accountId: normalizeAccountId(accountId),
+      }),
+    upsertPairingRequest: (input: { id: string; meta?: { name?: string } }) =>
+      params.core.channel.pairing.upsertPairingRequest({
+        channel: params.channel,
+        accountId: resolvedAccountId,
+        ...input,
+      }),
+  };
+}
+
 
 export type MonitorZulipOpts = {
   botEmail?: string;

--- a/src/zulip/probe.ts
+++ b/src/zulip/probe.ts
@@ -1,4 +1,4 @@
-import type { BaseProbeResult } from "openclaw/plugin-sdk";
+import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { Agent as HttpsAgent } from "node:https";
 import { normalizeZulipBaseUrl, readZulipError, type ZulipUser } from "./client.js";
 

--- a/src/zulip/reaction-loops.ts
+++ b/src/zulip/reaction-loops.ts
@@ -3,7 +3,7 @@
 // Manages rotating emoji reactions to indicate ongoing work.
 // Auto-cleanup after TTL to prevent orphaned reactions.
 
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { addZulipReaction, removeZulipReaction } from "./reactions.js";
 
 const DEFAULT_ICONS = ["thinking", "brain", "hourglass"];

--- a/src/zulip/reactions.ts
+++ b/src/zulip/reactions.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { resolveZulipAccount } from "./accounts.js";
 import { createZulipClient, fetchZulipMe, type ZulipClient } from "./client.js";
 

--- a/src/zulip/tools.ts
+++ b/src/zulip/tools.ts
@@ -4,7 +4,7 @@
 // so agents can call them like any other OpenClaw tool.
 
 import { Type } from "@sinclair/typebox";
-import type { AnyAgentTool } from "openclaw/plugin-sdk";
+import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import {
   createZulipClient,
   fetchZulipMessages,


### PR DESCRIPTION
Hey Gene! The plugin breaks on OpenClaw 2026.4.x because the monolithic \openclaw/plugin-sdk\ compat entry no longer exports several symbols (\createDedupeCache\, \esolveChannelMediaMaxBytes\, etc.).

**What was happening:**
- Plugin fails to load: \TypeError: (0 , _monitorHelpers.createDedupeCache) is not a function\
- Even after loading, channels crash: \(0 , _configRuntime.resolveChannelMediaMaxBytes) is not a function\
- The compat entry also emits a deprecation warning on every CLI invocation

**What this PR does:**
- Migrates all 16 source files from bare \openclaw/plugin-sdk\ imports to focused \openclaw/plugin-sdk/<subpath>\ imports
- Follows the same patterns used by the bundled Discord plugin
- Inlines \createScopedPairingAccess\ since it is no longer exported from any public subpath
- Eliminates the \OPENCLAW_PLUGIN_SDK_COMPAT_DEPRECATED\ warning

**Tested with:**
- OpenClaw 2026.4.14
- All 7 bot accounts connect and register event queues successfully
- No plugin load errors, no runtime crashes, no deprecation warnings