### PR TITLE
fix: OpenClaw 2026.5.12 plugin-sdk compatibility

### DIFF
--- a/src/zulip/monitor-helpers.ts
+++ b/src/zulip/monitor-helpers.ts
@@ -1,6 +1,6 @@
 import { formatInboundFromLabel as formatInboundFromLabelShared } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveThreadSessionKeys as resolveThreadSessionKeysShared } from "openclaw/plugin-sdk/core";
-export { rawDataToString } from "openclaw/plugin-sdk/browser-support";
+export { rawDataToString } from "openclaw/plugin-sdk/gateway-runtime";
 export { createDedupeCache } from "openclaw/plugin-sdk/core";
 
 export const formatInboundFromLabel = formatInboundFromLabelShared;


### PR DESCRIPTION
## Summary

Fixes the Zulip extension failing to load on OpenClaw v2026.5.12 due to a removed plugin-sdk subpath.

## Problem

```
Error: Cannot find module 'openclaw/plugin-sdk/browser-support'
Require stack:
- ~/.openclaw/extensions/zulip/src/zulip/monitor-helpers.ts
```

The `browser-support` subpath was removed from the plugin SDK in v2026.5.12 as part of the externalization refactor.

## Fix

Updated the import in `src/zulip/monitor-helpers.ts`:
```diff
- export { rawDataToString } from "openclaw/plugin-sdk/browser-support";
+ export { rawDataToString } from "openclaw/plugin-sdk/gateway-runtime";
```

`rawDataToString` is now exported from both `gateway-runtime` and `webhook-ingress` in v2026.5.12.

## Testing

- Applied on a production OpenClaw 2026.5.12 instance
- Gateway starts cleanly, Zulip plugin loads, all bot accounts connect successfully