### PR TITLE
fix: OpenClaw 2026.5.12 channel delivery and manifest compat

### DIFF
--- a/MIGRATION-5.12.md
+++ b/MIGRATION-5.12.md
@@ -1,0 +1,85 @@
+# Migration Guide: OpenClaw 2026.5.12
+
+This document covers required changes when upgrading from OpenClaw ≤2026.4.x to 2026.5.12.
+
+## Breaking Changes
+
+### 1. Plugin SDK Path Change
+
+The `browser-support` subpath was removed from the plugin SDK. If your extension imports from it:
+
+```diff
+- export { rawDataToString } from "openclaw/plugin-sdk/browser-support";
++ export { rawDataToString } from "openclaw/plugin-sdk/gateway-runtime";
+```
+
+`rawDataToString` is now exported from both `gateway-runtime` and `webhook-ingress`.
+
+### 2. Channel Auto-Delivery Requires Opt-In
+
+OpenClaw 5.12 defaults to `message_tool_only` for group/channel messages as a safety measure. Bots will process messages but won't auto-post responses unless you explicitly enable it.
+
+**Required config** in `~/.openclaw/openclaw.json`:
+```json
+{
+  "messages": {
+    "visibleReplies": "automatic"
+  }
+}
+```
+
+Without this, agents will show "Delivery: to send a message, use the message tool" in the web UI and responses won't appear in Zulip streams.
+
+### 3. Group Policy Enforcement
+
+`groupPolicy: "allowlist"` is now strictly enforced. If your accounts use `groupPolicy: "allowlist"` without a `groupAllowFrom` list, the bot will not deliver responses to streams.
+
+**Fix**: Either set `groupPolicy: "open"` on each account, or add explicit `groupAllowFrom` entries:
+```json
+{
+  "channels": {
+    "zulip": {
+      "accounts": {
+        "default": {
+          "groupPolicy": "open"
+        }
+      }
+    }
+  }
+}
+```
+
+### 4. Plugin Manifest: `contracts.tools`
+
+OpenClaw 5.12 requires plugins to declare their tools in `openclaw.plugin.json` before registering them at runtime. Without this, you'll see:
+
+```
+[gateway] [plugins] plugin must declare contracts.tools before registering agent tools
+```
+
+This is handled in this repo's `openclaw.plugin.json`.
+
+### 5. Externalized Plugins
+
+Amazon Bedrock and Brave Search were externalized from the OpenClaw core in 5.12. Install them separately:
+
+```bash
+openclaw plugins install @openclaw/amazon-bedrock-provider
+openclaw plugins install @openclaw/brave-plugin
+```
+
+## Recommended Upgrade Steps
+
+1. Back up config: `cp ~/.openclaw/openclaw.json ~/.openclaw/openclaw.json.bak`
+2. Stop the gateway: `systemctl --user stop openclaw-gateway.service`
+3. Upgrade OpenClaw: `sudo npm install -g openclaw@2026.5.12`
+4. Install externalized plugins (if used):
+   ```bash
+   openclaw plugins install @openclaw/amazon-bedrock-provider
+   openclaw plugins install @openclaw/brave-plugin
+   ```
+5. Update the Zulip extension to this branch
+6. Add `"messages": {"visibleReplies": "automatic"}` to config
+7. Set `groupPolicy: "open"` on accounts that should reply in streams
+8. Start the gateway: `systemctl --user start openclaw-gateway.service`
+9. Verify: `journalctl --user -u openclaw-gateway.service --since "1 minute ago" | grep -i error`

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,15 @@
 {
   "id": "zulip",
   "channels": ["zulip"],
+  "contracts": {
+    "tools": [
+      "zulip_fetch_messages",
+      "zulip_download_file",
+      "zulip_react_loop_start",
+      "zulip_react_loop_stop",
+      "zulip_react_loop_list"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -641,7 +641,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       ...mediaPayload,
     });
 
-    if (kind === "direct" || isGroupDm) {
+    {
       const sessionCfg = cfg.session;
       const storePath = core.channel.session.resolveStorePath(sessionCfg?.store, {
         agentId: route.agentId,


### PR DESCRIPTION
## Summary

Fixes channel message delivery and plugin manifest compatibility for OpenClaw v2026.5.12.

## Changes

### 1. `src/zulip/monitor.ts` — Persist delivery context for channel messages

Removed the `if (kind === "direct" || isGroupDm)` guard around `updateLastRoute`. Previously, only DM sessions stored their delivery context, which meant the gateway couldn't route follow-up messages (from web UI, cron, or ACP) back to Zulip streams.

```diff
-    if (kind === "direct" || isGroupDm) {
+    {
```

### 2. `openclaw.plugin.json` — Declare `contracts.tools`

OpenClaw 5.12 requires plugins to declare their tools in the manifest before runtime registration. Without this, the gateway logs:
```
[plugins] plugin must declare contracts.tools before registering agent tools
```

### 3. `MIGRATION-5.12.md` — Upgrade guide

Documents all breaking changes and required config for the 5.12 upgrade, including:
- `messages.visibleReplies: "automatic"` (required for channel auto-delivery)
- `groupPolicy: "open"` (required for stream responses)
- Externalized plugin installs (Bedrock, Brave)

## Testing

- Applied on a production OpenClaw 2026.5.12 instance
- All 5 Zulip bot accounts connect successfully
- Channel delivery works with `messages.visibleReplies: "automatic"` config
- No `contracts.tools` warnings in gateway logs

## Related

- PR #19 (plugin-sdk browser-support path fix — already merged)